### PR TITLE
Add a pre-commit for php sniffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged && ../../../../vendor/bin/phpcbf --standard=Drupal --ignore='*/css/*,*/dist/*,*/node_modules/*' ../../../../web/modules/custom ../../../../web/themes/custom"
     }
   },
   "author": "ThinkShout, Inc",


### PR DESCRIPTION
This is not ready to merge and is, in fact, likely something we should not do in the theme layer, but in the project layer. But it inspired me to figure out if we could do it using something like composer, and in fact we likely can. 

https://medium.com/@shalvah/hacking-it-out-ensuring-code-quality-with-hooks-and-scripts-c5113f0b0ec7

Dropping this in as a PR so I can have record of it, close it, and create a new issue for it in the Drupal Project.